### PR TITLE
Seems to fix the glitch of messing up zone's journal file

### DIFF
--- a/dzonegit.py
+++ b/dzonegit.py
@@ -119,7 +119,7 @@ def compile_zone(zonename, zonedata, unixtime=None, missing_dot=False):
         "CompileResults", "success, serial, zonehash, stderr",
     )
     r = subprocess.run(
-        ["/usr/sbin/named-compilezone", "-o", "-", zonename, "/dev/stdin"],
+        ["/usr/sbin/named-compilezone", "-j", "-o", "-", zonename, "/dev/stdin"],
         input=unixtime_directive(zonedata, unixtime),
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,


### PR DESCRIPTION
Not pretending I understand what exactly is going on behind the curtains, bud after instructing named-compilezone to take journal file into account the broken journal problem seems to go away. 