### PR TITLE
change named-compilezone to use /usr/bin/env rather than absolute path

### DIFF
--- a/dzonegit.py
+++ b/dzonegit.py
@@ -119,7 +119,7 @@ def compile_zone(zonename, zonedata, unixtime=None, missing_dot=False):
         "CompileResults", "success, serial, zonehash, stderr",
     )
     r = subprocess.run(
-        ["/usr/sbin/named-compilezone", "-o", "-", zonename, "/dev/stdin"],
+        ["/usr/bin/env", "named-compilezone", "-o", "-", zonename, "/dev/stdin"],
         input=unixtime_directive(zonedata, unixtime),
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ readme = Path(__file__).with_name("README.rst").read_text()
 
 setup(
     name="dzonegit",
-    version="0.11",
+    version="0.12",
     description="Git hooks to manage a repository of DNS zones",
     long_description=readme,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
Hardcoding /usr/sbin/named-compilezone is fine if we assume Linux everywhere, but not so much for other *nix systems (*bsd, brew.sh on Mac, etc).  "env" is required by Posix and is almost universally found at /usr/bin/env - the only two exceptions I was able to find are Unicos and NeXTstep.  Surely if the "#!/usr/bin/env python3" is good enough to be in the first line of the file it's good enough for finding named-compilezone too.  :)  Tested on SmartOS 19.4.0 (/opt/local/sbin/named-compilezone) and MacOS 10.14.6 with non-standard brew.sh installation (/opt/homebrew/sbin/named-compilezone).