### PR TITLE
Improve test by setting up the correct pre-state for test_get_zone_name

### DIFF
--- a/test_dzonegit.py
+++ b/test_dzonegit.py
@@ -156,6 +156,7 @@ $ORIGIN eXample.com. ;coment
         60 IN NS ns
 ns.example.com.      60 IN A 192.0.2.1
 """
+    subprocess.call(["git", "config", "dzonegit.allowfancynames", "FALSE"])
     assert "example.com" == dzonegit.get_zone_name(
         "zones/example.com.zone", "",
     )


### PR DESCRIPTION
This PR aims to improve the test by setting up the correct pre-state for `test_get_zone_name`.
If the pre-state is wrong (e.g., after running `git config dzonegit.allowfancynames TRUE`), `test_get_zone_name` can fail in the following way:
```
>           dzonegit.get_zone_name("zones/example.org.zone", testzone)
E           Failed: DID NOT RAISE <class 'ValueError'>
```