### PR TITLE
Reverting the latest commit to avoid state pollution

### DIFF
--- a/test_dzonegit.py
+++ b/test_dzonegit.py
@@ -27,6 +27,7 @@ def test_get_head(git_dir):
     subprocess.call(["git", "add", "dummy"])
     subprocess.call(["git", "commit", "-m", "dummy"])
     assert dzonegit.get_head() != "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+    subprocess.call(["git", "update-ref", "-d", "HEAD"])
 
 
 def test_check_whitespace_errors(git_dir):


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_get_head` by reverting the latest commit by executing command `git update-ref -d HEAD`

Note that command `git reset --soft HEAD^(or HEAD~1)` cannot be well recognized by `dzonegit`, with a error message below:
```
fatal: ambiguous argument '^HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```
The test can fail in this way if latest commit is not reverted:
```
>       assert dzonegit.get_head() == "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
E       AssertionError: assert 'e45c854b4065...d1d0a3108b75e' == '4b825dc642cb6...69288fbee4904'
E         - e45c854b4065ad2423373a85fb2d1d0a3108b75e
E         + 4b825dc642cb6eb9a060e54bf8d69288fbee4904