### PR TITLE
Apply whitespace check only on *.zone files.

### DIFF
--- a/dzonegit.py
+++ b/dzonegit.py
@@ -56,9 +56,9 @@ def get_head(empty=False):
 
 def check_whitespace_errors(against, revision=None):
     if revision:
-        cmd = ["git", "diff-tree", "--check", against, revision]
+        cmd = ["git", "diff-tree", "--check", against, revision, "*.zone"]
     else:
-        cmd = ["git", "diff-index", "--check", "--cached", against]
+        cmd = ["git", "diff-index", "--check", "--cached", against, "*.zone"]
     r = subprocess.run(
         cmd,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
The check_whitespace_errors checks all files in the repository using git diff-tree in the pre-commit hook. However only *.zone files should be checked. For example, if the repository contains README.md file with instructions (quite common setup), there is no way to pass the check if it contains code snippets with empty lines - like excerpts from configuration files.

Although the <path> argument of diff-tree is named "path", it behaves more like a pattern and an argument of "*.zone" properly matches any files with the "zone" extension both in the root of given repository and in any of its sub-directories at any depth.